### PR TITLE
Switch code blocks from JSON to YAML in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,19 @@ This is a base project for building systems in Python using FastAPI. It includes
 
 ### 1. Crie e configura o .env.
 
-``` json
+```yaml
     touch .env   
 ```
 
 ### 2. Builder no docker.
 
-``` json
+```yaml
     docker-compose build   
 ```
 
 ### 3. Suba o container
 
-``` json
+```yaml
     docker-compose up   
 ```
 


### PR DESCRIPTION
Changed the code block language notation from JSON to YAML for better clarity and correct representation in sections 1, 2, and 3. This ensures alignment with the actual file format being dealt with in these instructions.